### PR TITLE
Update 'How to use' link to version with fixed audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The exposure range (latitude) tester removes most of the guesswork on layer time
 
 All this with the added bonus of learning all in one go, the minimum viable width for positive and negative space details of each column exposure time.
 
-[How to use - Photonsters Youtube by Jay Sterling](https://www.youtube.com/watch?v=dguwzAg7Un4)
+[How to use - Photonsters Youtube by Jay Sterling](https://www.youtube.com/watch?v=P5p4IgZuqMA)
 
 ----
 


### PR DESCRIPTION
The YouTube video in the `REAMDE` links to an out of date video - the Photonsters YouTube channel has uploaded an updated version of the video with louder audio